### PR TITLE
Fix service injection in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with`shepherd.pool.<pool name>` naming convention.
 App\Service\MyService:
     class: App\Service\MyService
     arguments:
-        - 'shepherd.pool.foo'
+        - '@shepherd.pool.foo'
 ```
 
 You can keep adding new processes until starting the pool processing.


### PR DESCRIPTION
Hi, I'm not sure service injection works without '@' ? If it's really a mistake, there is the same in the related Medium story.